### PR TITLE
Fix dark mode

### DIFF
--- a/website/src/dependencies/_mixins.scss
+++ b/website/src/dependencies/_mixins.scss
@@ -1,7 +1,7 @@
 @mixin dark-mode {
   @if $dark-mode {
     @media (prefers-color-scheme: dark) {
-      @if (#{&} == 'body') {
+      @if (#{&} == ':global body') {
         &:global(:not(.light-mode)) {
           @content;
         }
@@ -11,7 +11,7 @@
         }
       }
     }
-    @if (#{&} == 'body') {
+    @if (#{&} == ':global body') {
       &:global(.dark-mode) {
         @content;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7016,11 +7016,6 @@ core-js@2, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.6.11, core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@2.6.10:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
-  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
-
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"


### PR DESCRIPTION
A recent update I made on `global.scss` broke the logic of the `dark-mode` mixin, leading to a partially broken dark mode.