### PR TITLE
Add netlify logo to the footer

### DIFF
--- a/website/src/templates/DefaultLayout.jsx
+++ b/website/src/templates/DefaultLayout.jsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
-import { useStaticQuery, graphql } from 'gatsby';
+import { Link, useStaticQuery, graphql } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
-import PropTypes from 'prop-types';
+import { PropTypes } from 'prop-types';
 
 import { SEO } from './SEO';
 import { CodeBlock } from '../components/CodeBlock';
@@ -115,16 +115,20 @@ const DefaultLayout = ({
         )}
       </HolyGrail.Body>
       <HolyGrail.Footer className={styles.Footer}>
-        <Grid full largeFit spacing="medium">
+        <Grid full largeFit spacing="medium" alignItems="center">
           <Grid.Column role="contentinfo">
             <p>
-              &copy; {new Date().getFullYear()}{' '}
-              <span
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={{
-                  __html: data.site.siteMetadata.htmlTitle,
-                }}
-              />
+              <Link
+                href="https://www.netlify.com/"
+                className={styles.NetlifyLogoLink}
+              >
+                <img
+                  src="https://www.netlify.com/img/global/badges/netlify-dark.svg"
+                  alt="Deploys by Netlify"
+                  width="114"
+                  height="51"
+                />
+              </Link>
             </p>
           </Grid.Column>
 

--- a/website/src/templates/DefaultLayout.module.scss
+++ b/website/src/templates/DefaultLayout.module.scss
@@ -97,3 +97,9 @@
   width: $sizing-xxlarge;
   height: $sizing-xxlarge;
 }
+
+.NetlifyLogoLink {
+  display: block;
+  width: 114px;
+  height: 51px;
+}


### PR DESCRIPTION
I'm applying for an open source account with Netlify ([using this form](https://opensource-form.netlify.com/)), and this change is required by [their open source policy](https://www.netlify.com/legal/open-source-policy/).

This also removes the copyright notice, as I don't know if it applies to the work we're doing (and I needed a space to put the logo 😓 ).